### PR TITLE
Update Mermaid Flow banner

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,61 +1,62 @@
 ---
 interface Props {
-	title: string;
-	body: string;
-	href: string;
+  title: string;
+  body: string;
+  href: string;
+  backgroundColor?: string;
 }
 
-const { href, title, body } = Astro.props;
+const { href, title, body, backgroundColor } = Astro.props;
 ---
 
 <li class="link-card">
-	<a href={href}>
-		<h2>
-			{title}
-			<span>&rarr;</span>
-		</h2>
-		<p>
-			{body}
-		</p>
-	</a>
+  <a href={href}>
+    <h2>
+      {title}
+      <span>&rarr;</span>
+    </h2>
+    <p>
+      {body}
+    </p>
+  </a>
 </li>
-<style>
-	.link-card {
-		list-style: none;
-		display: flex;
-		padding: 1px;
-		background-color: #23262d;
-		background-image: none;
-		background-size: 400%;
-		border-radius: 7px;
-		background-position: 100%;
-		transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-		box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
-	}
-	.link-card > a {
-		width: 100%;
-		text-decoration: none;
-		line-height: 1.4;
-		padding: calc(1.5rem - 1px);
-		border-radius: 8px;
-		color: white;
-		background-color: #23262d;
-		opacity: 0.8;
-	}
-	h2 {
-		margin: 0;
-		font-size: 1.25rem;
-		transition: color 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-	}
-	p {
-		margin-top: 0.5rem;
-		margin-bottom: 0;
-	}
-	.link-card:is(:hover, :focus-within) {
-		background-position: 0;
-		background-image: var(--accent-gradient);
-	}
-	.link-card:is(:hover, :focus-within) h2 {
-		color: rgb(var(--accent-light));
-	}
+<style define:vars={{ backgroundColor: backgroundColor ?? "#23262d" }}>
+  .link-card {
+    list-style: none;
+    display: flex;
+    padding: 1px;
+    background-color: var(--backgroundColor);
+    background-image: none;
+    background-size: 400%;
+    border-radius: 7px;
+    background-position: 100%;
+    transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  }
+  .link-card > a {
+    width: 100%;
+    text-decoration: none;
+    line-height: 1.4;
+    padding: calc(1.5rem - 1px);
+    border-radius: 8px;
+    color: white;
+    background-color: #23262d;
+    opacity: 0.8;
+  }
+  h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    transition: color 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  p {
+    margin-top: 0.5rem;
+    margin-bottom: 0;
+  }
+  .link-card:is(:hover, :focus-within) {
+    background-position: 0;
+    background-image: var(--accent-gradient);
+  }
+  .link-card:is(:hover, :focus-within) h2 {
+    color: rgb(var(--accent-light));
+  }
 </style>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,62 +1,62 @@
 ---
 interface Props {
-  title: string;
-  body: string;
-  href: string;
-  backgroundColor?: string;
+	title: string;
+	body: string;
+	href: string;
+	backgroundColor?: string;
 }
 
 const { href, title, body, backgroundColor } = Astro.props;
 ---
 
 <li class="link-card">
-  <a href={href}>
-    <h2>
-      {title}
-      <span>&rarr;</span>
-    </h2>
-    <p>
-      {body}
-    </p>
-  </a>
+	<a href={href}>
+		<h2>
+			{title}
+			<span>&rarr;</span>
+		</h2>
+		<p>
+			{body}
+		</p>
+	</a>
 </li>
 <style define:vars={{ backgroundColor: backgroundColor ?? "#23262d" }}>
-  .link-card {
-    list-style: none;
-    display: flex;
-    padding: 1px;
-    background-color: var(--backgroundColor);
-    background-image: none;
-    background-size: 400%;
-    border-radius: 7px;
-    background-position: 100%;
-    transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
-  }
-  .link-card > a {
-    width: 100%;
-    text-decoration: none;
-    line-height: 1.4;
-    padding: calc(1.5rem - 1px);
-    border-radius: 8px;
-    color: white;
-    background-color: #23262d;
-    opacity: 0.8;
-  }
-  h2 {
-    margin: 0;
-    font-size: 1.25rem;
-    transition: color 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-  }
-  p {
-    margin-top: 0.5rem;
-    margin-bottom: 0;
-  }
-  .link-card:is(:hover, :focus-within) {
-    background-position: 0;
-    background-image: var(--accent-gradient);
-  }
-  .link-card:is(:hover, :focus-within) h2 {
-    color: rgb(var(--accent-light));
-  }
+	.link-card {
+		list-style: none;
+		display: flex;
+		padding: 1px;
+		background-color: var(--backgroundColor);
+		background-image: none;
+		background-size: 400%;
+		border-radius: 7px;
+		background-position: 100%;
+		transition: background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+		box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+	}
+	.link-card > a {
+		width: 100%;
+		text-decoration: none;
+		line-height: 1.4;
+		padding: calc(1.5rem - 1px);
+		border-radius: 8px;
+		color: white;
+		background-color: #23262d;
+		opacity: 0.8;
+	}
+	h2 {
+		margin: 0;
+		font-size: 1.25rem;
+		transition: color 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+	}
+	p {
+		margin-top: 0.5rem;
+		margin-bottom: 0;
+	}
+	.link-card:is(:hover, :focus-within) {
+		background-position: 0;
+		background-image: var(--accent-gradient);
+	}
+	.link-card:is(:hover, :focus-within) h2 {
+		color: rgb(var(--accent-light));
+	}
 </style>

--- a/src/components/banner.astro
+++ b/src/components/banner.astro
@@ -5,8 +5,8 @@ import Card from "./Card.astro";
 ---
 
 <Card
-  title="Mermaid Flow"
-  body="Create diagrams visually!"
-  href="https://www.mermaidflow.app/pricing?ref=jace"
-  backgroundColor="white"
+	title="Mermaid Flow"
+	body="Create diagrams visually!"
+	href="https://www.mermaidflow.app/pricing?ref=jace"
+	backgroundColor="white"
 />

--- a/src/components/banner.astro
+++ b/src/components/banner.astro
@@ -1,39 +1,12 @@
 ---
+import Card from "./Card.astro";
+
 //
 ---
 
-<p class="instructions">
-    Create Diagrams visually.
-    <br />
-    <a
-        href="https://www.mermaidflow.app/?ref=jace"
-        target="_blank"
-        rel="noopener"
-    >
-        <strong>MermaidFlow</strong>
-    </a>
-</p>
-
-<style>
-    .instructions {
-        margin-bottom: 2rem;
-        border: 1px solid rgba(var(--accent-light), 25%);
-        background: linear-gradient(
-            rgba(var(--accent-dark), 66%),
-            rgba(var(--accent-dark), 33%)
-        );
-        padding: 1.5rem;
-        border-radius: 8px;
-    }
-    .instructions code {
-        font-size: 0.8em;
-        font-weight: bold;
-        background: rgba(var(--accent-light), 12%);
-        color: rgb(var(--accent-light));
-        border-radius: 4px;
-        padding: 0.3em 0.4em;
-    }
-    .instructions strong {
-        color: rgb(var(--accent-light));
-    }
-</style>
+<Card
+  title="Mermaid Flow"
+  body="Create diagrams visually!"
+  href="https://www.mermaidflow.app/pricing?ref=jace"
+  backgroundColor="white"
+/>


### PR DESCRIPTION
Up to you but this will probably convert better. If you wanted it to convert even better, i'd suggest a typewriter effect that animates from "Create diagrams visually.", "Create diagrams with AI.", "Create diagrams fast."

This library is one option: https://www.typeitjs.com/

Normal

![Screenshot 2024-07-09 at 3 06 46 pm](https://github.com/jacebenson/workflow-astro/assets/38032037/e2165917-2888-400f-8312-62fbf1efb2f8)

On hover

![Screenshot 2024-07-09 at 3 06 53 pm](https://github.com/jacebenson/workflow-astro/assets/38032037/cd209965-5666-4aed-9566-377e925639d3)

If you don't want this banner, feel free to edit to your liking or at least change "MermaidFlow" to "Mermaid Flow" with a space.

Thank you!
